### PR TITLE
Allow building without proc_macro dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,9 @@ license = "MIT/Apache-2.0"
 description = "Procedural functionlike!() macros using only Macros 1.1"
 repository = "https://github.com/dtolnay/proc-macro-hack"
 
+[features]
+default = ["proc_macro"]
+proc_macro = []
+
 [dependencies]
 proc-macro-hack-impl = { version = "0.3", path = "impl" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "proc_macro")]
 extern crate proc_macro;
 
 // Allow the "unused" #[macro_use] because there is a different un-ignorable
@@ -9,8 +10,27 @@ extern crate proc_macro;
 extern crate proc_macro_hack_impl;
 pub use proc_macro_hack_impl::*;
 
+#[cfg(feature = "proc_macro")]
 #[doc(hidden)]
 pub use proc_macro::TokenStream;
+
+#[cfg(feature = "proc_macro")]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! proc_macro_tokenstream {
+    () => {
+        $crate::TokenStream
+    }
+}
+
+#[cfg(not(feature = "proc_macro"))]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! proc_macro_tokenstream {
+    () => {
+        ::proc_macro::TokenStream
+    }
+}
 
 #[macro_export]
 macro_rules! proc_macro_expr_decl {
@@ -43,7 +63,7 @@ macro_rules! proc_macro_expr_impl {
         $(
             $( #[$attr] )*
             #[proc_macro_derive($func)]
-            pub fn $func(input: $crate::TokenStream) -> $crate::TokenStream {
+            pub fn $func(input: proc_macro_tokenstream!()) -> proc_macro_tokenstream!() {
                 let source = input.to_string();
                 let source = source.trim();
 
@@ -88,7 +108,7 @@ macro_rules! proc_macro_item_impl {
         $(
             $( #[$attr] )*
             #[proc_macro_derive($func)]
-            pub fn $func(input: $crate::TokenStream) -> $crate::TokenStream {
+            pub fn $func(input: proc_macro_tokenstream!()) -> proc_macro_tokenstream!() {
                 let source = input.to_string();
                 let source = source.trim();
 


### PR DESCRIPTION
@golddranks this lets you disable the proc_macro dependency:

```toml
proc-macro-hack = { version = "0.3", default-features = false }
```

The only catch is that then your crate is responsible for providing `::proc_macro`, but as I understand it this should work with musl target.

```rust
extern crate proc_macro;

#[macro_use]
extern crate proc_macro_hack;

proc_macro_expr_impl! {
    /* ... */
}
```

Fixes #6.