### PR TITLE
array-macro is no longer using proc-macro-hack

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ fn main() {
 - [`binary_macros`] – Macros for decoding base64 and hexadecimal-like encodings
   from string literals to [u8] literals at compile time.
 - [`autoimpl`] – Macro to generate a default blanket impl for a generic trait.
-- [`array-macro`] – Macro for concisely building large arrays.
 - [`reql`] – Includes a macro to splice an array of ReQL arguments into another
   term.
 
@@ -135,7 +134,6 @@ fn main() {
 [`hexf`]: https://github.com/lifthrasiir/hexf
 [`binary_macros`]: https://github.com/golddranks/binary_macros
 [`autoimpl`]: https://github.com/blakepettersson/autoimpl
-[`array-macro`]: https://docs.rs/array-macro/0.1.1/array_macro/
 [`reql`]: https://docs.rs/reql/0.0.8/reql/macro.args.html
 
 ## Limitations


### PR DESCRIPTION
Nice crate by the way, unfortunate that Rust changes forced me to not use this crate anymore. Figured out how to implement it without proc-macro-hack however.

The array-macro-internal stays because it's needed for old versions of array-macro, even if it's no longer a dependency.