### PR TITLE
remove reference to reql crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,6 @@ fn main() {
 - [`binary_macros`] – Macros for decoding base64 and hexadecimal-like encodings
   from string literals to [u8] literals at compile time.
 - [`autoimpl`] – Macro to generate a default blanket impl for a generic trait.
-- [`reql`] – Includes a macro to splice an array of ReQL arguments into another
-  term.
 
 [`mashup`]: https://github.com/dtolnay/mashup
 [`indoc`]: https://github.com/dtolnay/indoc
@@ -136,7 +134,6 @@ fn main() {
 [`hexf`]: https://github.com/lifthrasiir/hexf
 [`binary_macros`]: https://github.com/golddranks/binary_macros
 [`autoimpl`]: https://github.com/blakepettersson/autoimpl
-[`reql`]: https://docs.rs/reql/0.0.8/reql/macro.args.html
 
 ## Limitations
 


### PR DESCRIPTION
It no longer uses this crate due to https://github.com/dtolnay/proc-macro-hack/issues/15.