### PR TITLE
Support referring to local variables not named in the macro input

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ fn main() {
   proc-macro-hack macro nor calls to any other proc-macro-hack macros. Use
   [`proc-macro-nested`] if you require support for nested invocations.
 
+- By default, hygiene is structured such that the expanded code can't refer to
+  local variables other than those passed by name somewhere in the macro input.
+  If your macro must refer to *local* variables that don't get named in the
+  macro input, use `#[proc_macro_hack(fake_call_site)]` on the re-export in your
+  declaration crate. *Most macros won't need this.*
+
 [#10]: https://github.com/dtolnay/proc-macro-hack/issues/10
 [#20]: https://github.com/dtolnay/proc-macro-hack/issues/20
 [`proc-macro-nested`]: https://docs.rs/proc-macro-nested

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,12 @@
 //!   same proc-macro-hack macro nor calls to any other proc-macro-hack macros.
 //!   Use [`proc-macro-nested`] if you require support for nested invocations.
 //!
+//! - By default, hygiene is structured such that the expanded code can't refer
+//!   to local variables other than those passed by name somewhere in the macro
+//!   input. If your macro must refer to *local* variables that don't get named
+//!   in the macro input, use `#[proc_macro_hack(fake_call_site)]` on the
+//!   re-export in your declaration crate. *Most macros won't need this.*
+//!
 //! [#10]: https://github.com/dtolnay/proc-macro-hack/issues/10
 //! [#20]: https://github.com/dtolnay/proc-macro-hack/issues/20
 //! [`proc-macro-nested`]: https://docs.rs/proc-macro-nested

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,18 +265,41 @@ pub fn proc_macro_hack(
 }
 
 mod kw {
+    syn::custom_keyword!(derive);
+    syn::custom_keyword!(fake_call_site);
     syn::custom_keyword!(support_nested);
 }
 
 struct ExportArgs {
     support_nested: bool,
+    fake_call_site: bool,
 }
 
 impl Parse for ExportArgs {
     fn parse(input: ParseStream) -> Result<Self> {
-        Ok(ExportArgs {
-            support_nested: input.parse::<Option<kw::support_nested>>()?.is_some(),
-        })
+        let mut args = ExportArgs {
+            support_nested: false,
+            fake_call_site: false,
+        };
+
+        while !input.is_empty() {
+            let ahead = input.lookahead1();
+            if ahead.peek(kw::support_nested) {
+                input.parse::<kw::support_nested>()?;
+                args.support_nested = true;
+            } else if ahead.peek(kw::fake_call_site) {
+                input.parse::<kw::fake_call_site>()?;
+                args.fake_call_site = true;
+            } else {
+                return Err(ahead.error());
+            }
+            if input.is_empty() {
+                break;
+            }
+            input.parse::<Token![,]>()?;
+        }
+
+        Ok(args)
     }
 }
 
@@ -328,6 +351,51 @@ pub fn enum_hack(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     proc_macro::TokenStream::from(inner.token_stream)
 }
 
+struct FakeCallSite {
+    derive: Ident,
+    rest: TokenStream,
+}
+
+impl Parse for FakeCallSite {
+    fn parse(input: ParseStream) -> Result<Self> {
+        input.parse::<Token![#]>()?;
+        let attr;
+        bracketed!(attr in input);
+        attr.parse::<kw::derive>()?;
+        let path;
+        parenthesized!(path in attr);
+        Ok(FakeCallSite {
+            derive: path.parse()?,
+            rest: input.parse()?,
+        })
+    }
+}
+
+#[doc(hidden)]
+#[proc_macro_attribute]
+pub fn fake_call_site(
+    args: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let args = TokenStream::from(args);
+    let span = match args.into_iter().next() {
+        Some(token) => token.span(),
+        None => return input,
+    };
+
+    let input = parse_macro_input!(input as FakeCallSite);
+    let mut derive = input.derive;
+    derive.set_span(span);
+    let rest = input.rest;
+
+    let expanded = quote! {
+        #[derive(#derive)]
+        #rest
+    };
+
+    proc_macro::TokenStream::from(expanded)
+}
+
 fn expand_export(export: Export, args: ExportArgs) -> TokenStream {
     let dummy = dummy_name_for_export(&export);
 
@@ -337,10 +405,7 @@ fn expand_export(export: Export, args: ExportArgs) -> TokenStream {
         Some(_) => quote!(#[macro_export]),
         None => quote!(),
     };
-    let crate_prefix = match vis {
-        Some(_) => quote!($crate::),
-        None => quote!(),
-    };
+    let crate_prefix = vis.map(|_| quote!($crate::));
     let enum_variant = if args.support_nested {
         quote!(Nested)
     } else {
@@ -354,14 +419,15 @@ fn expand_export(export: Export, args: ExportArgs) -> TokenStream {
         .map(|Macro { name, export_as }| {
             let actual_name = actual_proc_macro_name(&name);
             let dispatch = dispatch_macro_name(&name);
+            let call_site = call_site_macro_name(&name);
 
             let export_dispatch = if args.support_nested {
-                Some(quote! {
+                quote! {
                     #[doc(hidden)]
                     #vis use proc_macro_nested::dispatch as #dispatch;
-                })
+                }
             } else {
-                None
+                quote!()
             };
 
             let proc_macro_call = if args.support_nested {
@@ -374,17 +440,44 @@ fn expand_export(export: Export, args: ExportArgs) -> TokenStream {
                 }
             };
 
+            let export_call_site = if args.fake_call_site {
+                quote! {
+                    #[doc(hidden)]
+                    #vis use proc_macro_hack::fake_call_site as #call_site;
+                }
+            } else {
+                quote!()
+            };
+
+            let do_derive = if !args.fake_call_site {
+                quote! {
+                    #[derive(#crate_prefix #actual_name)]
+                }
+            } else if crate_prefix.is_some() {
+                quote! {
+                    use #crate_prefix #actual_name;
+                    #[#crate_prefix #call_site ($($proc_macro)*)]
+                    #[derive(#actual_name)]
+                }
+            } else {
+                quote! {
+                    #[#call_site ($($proc_macro)*)]
+                    #[derive(#actual_name)]
+                }
+            };
+
             quote! {
                 #[doc(hidden)]
                 #vis use #from::#actual_name;
 
                 #export_dispatch
+                #export_call_site
 
                 #attrs
                 #macro_export
                 macro_rules! #export_as {
                     ($($proc_macro:tt)*) => {{
-                        #[derive(#crate_prefix #actual_name)]
+                        #do_derive
                         enum ProcMacroHack {
                             #enum_variant = (stringify! { $($proc_macro)* }, 0).1,
                         }
@@ -509,6 +602,11 @@ fn actual_proc_macro_name(conceptual: &Ident) -> Ident {
 
 fn dispatch_macro_name(conceptual: &Ident) -> Ident {
     let dispatch = format!("proc_macro_call_{}", conceptual);
+    Ident::new(&dispatch, Span::call_site())
+}
+
+fn call_site_macro_name(conceptual: &Ident) -> Ident {
+    let dispatch = format!("proc_macro_fake_call_site_{}", conceptual);
     Ident::new(&dispatch, Span::call_site())
 }
 


### PR DESCRIPTION
Fixes #31.

> - By default, hygiene is structured such that the expanded code can't refer to local variables other than those passed by name somewhere in the macro input. If your macro must refer to *local* variables that don't get named in the macro input, use `#[proc_macro_hack(fake_call_site)]` on the re-export in your declaration crate.