### PR TITLE
Reexport now handles optional leading `::` in path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,6 +186,7 @@ impl Parse for Export {
         let attrs = input.call(parse_attributes)?;
         let vis: Visibility = input.parse()?;
         input.parse::<Token![use]>()?;
+        input.parse::<Option<Token![::]>>()?;
         let from: Ident = input.parse()?;
         input.parse::<Token![::]>()?;
 


### PR DESCRIPTION
Fixes https://github.com/dtolnay/proc-macro-hack/issues/36