### PR TITLE
Escape raw identifiers in macro export name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proc-macro-hack"
-version = "0.5.10"
+version = "0.5.11"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -634,11 +634,17 @@ fn call_site_macro_name(conceptual: &Ident) -> Ident {
     format_ident!("proc_macro_fake_call_site_{}", conceptual)
 }
 
+fn escape_raw_identifier(ident: &str) -> String {
+    ident.replace("r#", "")
+}
+
 fn dummy_name_for_export(export: &Export) -> String {
     let mut dummy = String::new();
-    write!(dummy, "_{}{}", export.from.to_string().len(), export.from).unwrap();
+    let from = escape_raw_identifier(&export.from.to_string());
+    write!(dummy, "_{}{}", from.len(), from).unwrap();
     for m in &export.macros {
-        write!(dummy, "_{}{}", m.name.to_string().len(), m.name).unwrap();
+        let name = escape_raw_identifier(&m.name.to_string());
+        write!(dummy, "_{}{}", name.len(), name).unwrap();
     }
     dummy
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -634,16 +634,22 @@ fn call_site_macro_name(conceptual: &Ident) -> Ident {
     format_ident!("proc_macro_fake_call_site_{}", conceptual)
 }
 
-fn escape_raw_identifier(ident: &str) -> String {
-    ident.replace("r#", "")
+fn escape_raw_identifier(ident: &str) -> &str {
+    if ident.starts_with("r#") {
+        &ident[2..]
+    } else {
+        ident
+    }
 }
 
 fn dummy_name_for_export(export: &Export) -> String {
     let mut dummy = String::new();
-    let from = escape_raw_identifier(&export.from.to_string());
+    let from = export.from.to_string();
+    let from = escape_raw_identifier(&from);
     write!(dummy, "_{}{}", from.len(), from).unwrap();
     for m in &export.macros {
-        let name = escape_raw_identifier(&m.name.to_string());
+        let name = m.name.to_string();
+        let name = escape_raw_identifier(&name);
         write!(dummy, "_{}{}", name.len(), name).unwrap();
     }
     dummy


### PR DESCRIPTION
Allows to export macros defined using raw identifiers. For example:
```rust
#[proc_macro_hack]
pub fn r#async(input: TokenStream) -> TokenStream { ... }
```