### PR TITLE
Add error message for nested macros above the limit

### DIFF
--- a/nested/build.rs
+++ b/nested/build.rs
@@ -31,6 +31,9 @@ fn main() {
         content += &format!("({}) => {{ proc_macro_call_{}!() }};", bangs, i);
     }
     content += "
+            ($(!)+) => {
+                compile_error!(\"this macro does not support >64 nested macro invocations\")
+            };
         }
     ";
 


### PR DESCRIPTION
Fixes #50.

```console
error: this macro does not support >64 nested macro invocations
  --> src/main.rs:13:9
   |
13 | /         select! {
14 | |             _ = next_msg => {
15 | |                 println!("1");
16 | |                 println!("2");
...  |
80 | |             }
81 | |         }
   | |_________^
```